### PR TITLE
include LICENSE in MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 graft ot/lp/
 include README.md
+include LICENSE
 include ot/lp/core.h
 include ot/lp/EMD.h
 include ot/lp/EMD_wrapper.cpp


### PR DESCRIPTION
It's generally good practice to distribute the text of the license with your package; this change makes sure that your `LICENSE` file ends up in the pypi tar files. (It currently doesn't.)

(This came up because I'm putting together a [conda-forge](http://conda-forge.github.io) recipe for POT, which ideally wants a file with the license text.)