### PR TITLE
remove automatic imports from ot/__init__.py

### DIFF
--- a/ot/__init__.py
+++ b/ot/__init__.py
@@ -10,28 +10,28 @@
 # License: MIT License
 
 
-# All submodules and packages
-from . import lp
-from . import bregman
-from . import optim
-from . import utils
-from . import datasets
-from . import plot
-from . import da
-from . import gromov
+# # All submodules and packages
+# from . import lp
+# from . import bregman
+# from . import optim
+# from . import utils
+# from . import datasets
+# from . import plot
+# from . import da
+# from . import gromov
 
-# OT functions
-from .lp import emd, emd2
-from .bregman import sinkhorn, sinkhorn2, barycenter
-from .da import sinkhorn_lpl1_mm
-from .gromov import gromov_wasserstein, gromov_wasserstein2
+# # OT functions
+# from .lp import emd, emd2
+# from .bregman import sinkhorn, sinkhorn2, barycenter
+# from .da import sinkhorn_lpl1_mm
+# from .gromov import gromov_wasserstein, gromov_wasserstein2
 
-# utils functions
-from .utils import dist, unif, tic, toc, toq
+# # utils functions
+# from .utils import dist, unif, tic, toc, toq
 
 __version__ = "0.4.0"
 
-__all__ = ["emd", "emd2", "sinkhorn", "sinkhorn2", "utils", 'datasets',
-           'bregman', 'lp', 'plot', 'tic', 'toc', 'toq',
-           'dist', 'unif', 'barycenter', 'sinkhorn_lpl1_mm', 'da', 'optim', 
-           'gromov_wasserstein','gromov_wasserstein2']
+# __all__ = ["emd", "emd2", "sinkhorn", "sinkhorn2", "utils", 'datasets',
+#            'bregman', 'lp', 'plot', 'tic', 'toc', 'toq',
+#            'dist', 'unif', 'barycenter', 'sinkhorn_lpl1_mm', 'da', 'optim',
+#            'gromov_wasserstein', 'gromov_wasserstein2']

--- a/ot/__init__.py
+++ b/ot/__init__.py
@@ -9,29 +9,4 @@
 #
 # License: MIT License
 
-
-# # All submodules and packages
-# from . import lp
-# from . import bregman
-# from . import optim
-# from . import utils
-# from . import datasets
-# from . import plot
-# from . import da
-# from . import gromov
-
-# # OT functions
-# from .lp import emd, emd2
-# from .bregman import sinkhorn, sinkhorn2, barycenter
-# from .da import sinkhorn_lpl1_mm
-# from .gromov import gromov_wasserstein, gromov_wasserstein2
-
-# # utils functions
-# from .utils import dist, unif, tic, toc, toq
-
 __version__ = "0.4.0"
-
-# __all__ = ["emd", "emd2", "sinkhorn", "sinkhorn2", "utils", 'datasets',
-#            'bregman', 'lp', 'plot', 'tic', 'toc', 'toq',
-#            'dist', 'unif', 'barycenter', 'sinkhorn_lpl1_mm', 'da', 'optim',
-#            'gromov_wasserstein', 'gromov_wasserstein2']

--- a/test/test_bregman.py
+++ b/test/test_bregman.py
@@ -5,7 +5,9 @@
 # License: MIT License
 
 import numpy as np
-import ot
+from ot.utils import unif, dist, dist0
+from ot.bregman import sinkhorn, barycenter, unmix
+from ot.datasets import get_1D_gauss
 
 
 def test_sinkhorn():
@@ -14,11 +16,11 @@ def test_sinkhorn():
     rng = np.random.RandomState(0)
 
     x = rng.randn(n, 2)
-    u = ot.utils.unif(n)
+    u = unif(n)
 
-    M = ot.dist(x, x)
+    M = dist(x, x)
 
-    G = ot.sinkhorn(u, u, M, 1, stopThr=1e-10)
+    G = sinkhorn(u, u, M, 1, stopThr=1e-10)
 
     # check constratints
     np.testing.assert_allclose(
@@ -33,22 +35,22 @@ def test_sinkhorn_empty():
     rng = np.random.RandomState(0)
 
     x = rng.randn(n, 2)
-    u = ot.utils.unif(n)
+    u = unif(n)
 
-    M = ot.dist(x, x)
+    M = dist(x, x)
 
-    G, log = ot.sinkhorn([], [], M, 1, stopThr=1e-10, verbose=True, log=True)
+    G, log = sinkhorn([], [], M, 1, stopThr=1e-10, verbose=True, log=True)
     # check constratints
     np.testing.assert_allclose(u, G.sum(1), atol=1e-05)
     np.testing.assert_allclose(u, G.sum(0), atol=1e-05)
 
-    G, log = ot.sinkhorn([], [], M, 1, stopThr=1e-10,
-                         method='sinkhorn_stabilized', verbose=True, log=True)
+    G, log = sinkhorn([], [], M, 1, stopThr=1e-10,
+                      method='sinkhorn_stabilized', verbose=True, log=True)
     # check constratints
     np.testing.assert_allclose(u, G.sum(1), atol=1e-05)
     np.testing.assert_allclose(u, G.sum(0), atol=1e-05)
 
-    G, log = ot.sinkhorn(
+    G, log = sinkhorn(
         [], [], M, 1, stopThr=1e-10, method='sinkhorn_epsilon_scaling',
         verbose=True, log=True)
     # check constratints
@@ -62,15 +64,15 @@ def test_sinkhorn_variants():
     rng = np.random.RandomState(0)
 
     x = rng.randn(n, 2)
-    u = ot.utils.unif(n)
+    u = unif(n)
 
-    M = ot.dist(x, x)
+    M = dist(x, x)
 
-    G0 = ot.sinkhorn(u, u, M, 1, method='sinkhorn', stopThr=1e-10)
-    Gs = ot.sinkhorn(u, u, M, 1, method='sinkhorn_stabilized', stopThr=1e-10)
-    Ges = ot.sinkhorn(
+    G0 = sinkhorn(u, u, M, 1, method='sinkhorn', stopThr=1e-10)
+    Gs = sinkhorn(u, u, M, 1, method='sinkhorn_stabilized', stopThr=1e-10)
+    Ges = sinkhorn(
         u, u, M, 1, method='sinkhorn_epsilon_scaling', stopThr=1e-10)
-    Gerr = ot.sinkhorn(u, u, M, 1, method='do_not_exists', stopThr=1e-10)
+    Gerr = sinkhorn(u, u, M, 1, method='do_not_exists', stopThr=1e-10)
 
     # check values
     np.testing.assert_allclose(G0, Gs, atol=1e-05)
@@ -83,14 +85,14 @@ def test_bary():
     n_bins = 100  # nb bins
 
     # Gaussian distributions
-    a1 = ot.datasets.get_1D_gauss(n_bins, m=30, s=10)  # m= mean, s= std
-    a2 = ot.datasets.get_1D_gauss(n_bins, m=40, s=10)
+    a1 = get_1D_gauss(n_bins, m=30, s=10)  # m= mean, s= std
+    a2 = get_1D_gauss(n_bins, m=40, s=10)
 
     # creating matrix A containing all distributions
     A = np.vstack((a1, a2)).T
 
     # loss matrix + normalization
-    M = ot.utils.dist0(n_bins)
+    M = dist0(n_bins)
     M /= M.max()
 
     alpha = 0.5  # 0<=alpha<=1
@@ -98,11 +100,11 @@ def test_bary():
 
     # wasserstein
     reg = 1e-3
-    bary_wass = ot.bregman.barycenter(A, M, reg, weights)
+    bary_wass = barycenter(A, M, reg, weights)
 
     np.testing.assert_allclose(1, np.sum(bary_wass))
 
-    ot.bregman.barycenter(A, M, reg, log=True, verbose=True)
+    barycenter(A, M, reg, log=True, verbose=True)
 
 
 def test_unmix():
@@ -110,28 +112,28 @@ def test_unmix():
     n_bins = 50  # nb bins
 
     # Gaussian distributions
-    a1 = ot.datasets.get_1D_gauss(n_bins, m=20, s=10)  # m= mean, s= std
-    a2 = ot.datasets.get_1D_gauss(n_bins, m=40, s=10)
+    a1 = get_1D_gauss(n_bins, m=20, s=10)  # m= mean, s= std
+    a2 = get_1D_gauss(n_bins, m=40, s=10)
 
-    a = ot.datasets.get_1D_gauss(n_bins, m=30, s=10)
+    a = get_1D_gauss(n_bins, m=30, s=10)
 
     # creating matrix A containing all distributions
     D = np.vstack((a1, a2)).T
 
     # loss matrix + normalization
-    M = ot.utils.dist0(n_bins)
+    M = dist0(n_bins)
     M /= M.max()
 
-    M0 = ot.utils.dist0(2)
+    M0 = dist0(2)
     M0 /= M0.max()
-    h0 = ot.unif(2)
+    h0 = unif(2)
 
     # wasserstein
     reg = 1e-3
-    um = ot.bregman.unmix(a, D, M, M0, h0, reg, 1, alpha=0.01,)
+    um = unmix(a, D, M, M0, h0, reg, 1, alpha=0.01,)
 
     np.testing.assert_allclose(1, np.sum(um), rtol=1e-03, atol=1e-03)
     np.testing.assert_allclose([0.5, 0.5], um, rtol=1e-03, atol=1e-03)
 
-    ot.bregman.unmix(a, D, M, M0, h0, reg,
-                     1, alpha=0.01, log=True, verbose=True)
+    unmix(a, D, M, M0, h0, reg,
+          1, alpha=0.01, log=True, verbose=True)

--- a/test/test_da.py
+++ b/test/test_da.py
@@ -7,9 +7,17 @@
 import numpy as np
 from numpy.testing.utils import assert_allclose, assert_equal
 
-import ot
+# import ot
+from ot.da import (SinkhornTransport, SinkhornL1l2Transport,
+                   SinkhornLpl1Transport, EMDTransport,
+                   MappingTransport)
+
 from ot.datasets import get_data_classif
 from ot.utils import unif
+
+# deprecated otda classes
+from ot.da import (OTDA, OTDA_l1l2, OTDA_lpl1, OTDA_sinkhorn,
+                   OTDA_mapping_kernel, OTDA_mapping_linear)
 
 
 def test_sinkhorn_lpl1_transport_class():
@@ -22,7 +30,7 @@ def test_sinkhorn_lpl1_transport_class():
     Xs, ys = get_data_classif('3gauss', ns)
     Xt, yt = get_data_classif('3gauss2', nt)
 
-    otda = ot.da.SinkhornLpl1Transport()
+    otda = SinkhornLpl1Transport()
 
     # test its computed
     otda.fit(Xs=Xs, ys=ys, Xt=Xt)
@@ -66,11 +74,11 @@ def test_sinkhorn_lpl1_transport_class():
     assert_equal(transp_Xs.shape, Xs.shape)
 
     # test unsupervised vs semi-supervised mode
-    otda_unsup = ot.da.SinkhornLpl1Transport()
+    otda_unsup = SinkhornLpl1Transport()
     otda_unsup.fit(Xs=Xs, ys=ys, Xt=Xt)
     n_unsup = np.sum(otda_unsup.cost_)
 
-    otda_semi = ot.da.SinkhornLpl1Transport()
+    otda_semi = SinkhornLpl1Transport()
     otda_semi.fit(Xs=Xs, ys=ys, Xt=Xt, yt=yt)
     assert_equal(otda_semi.cost_.shape, ((Xs.shape[0], Xt.shape[0])))
     n_semisup = np.sum(otda_semi.cost_)
@@ -95,7 +103,7 @@ def test_sinkhorn_l1l2_transport_class():
     Xs, ys = get_data_classif('3gauss', ns)
     Xt, yt = get_data_classif('3gauss2', nt)
 
-    otda = ot.da.SinkhornL1l2Transport()
+    otda = SinkhornL1l2Transport()
 
     # test its computed
     otda.fit(Xs=Xs, ys=ys, Xt=Xt)
@@ -140,11 +148,11 @@ def test_sinkhorn_l1l2_transport_class():
     assert_equal(transp_Xs.shape, Xs.shape)
 
     # test unsupervised vs semi-supervised mode
-    otda_unsup = ot.da.SinkhornL1l2Transport()
+    otda_unsup = SinkhornL1l2Transport()
     otda_unsup.fit(Xs=Xs, ys=ys, Xt=Xt)
     n_unsup = np.sum(otda_unsup.cost_)
 
-    otda_semi = ot.da.SinkhornL1l2Transport()
+    otda_semi = SinkhornL1l2Transport()
     otda_semi.fit(Xs=Xs, ys=ys, Xt=Xt, yt=yt)
     assert_equal(otda_semi.cost_.shape, ((Xs.shape[0], Xt.shape[0])))
     n_semisup = np.sum(otda_semi.cost_)
@@ -161,7 +169,7 @@ def test_sinkhorn_l1l2_transport_class():
                     rtol=1e-9, atol=1e-9)
 
     # check everything runs well with log=True
-    otda = ot.da.SinkhornL1l2Transport(log=True)
+    otda = SinkhornL1l2Transport(log=True)
     otda.fit(Xs=Xs, ys=ys, Xt=Xt)
     assert len(otda.log_.keys()) != 0
 
@@ -176,7 +184,7 @@ def test_sinkhorn_transport_class():
     Xs, ys = get_data_classif('3gauss', ns)
     Xt, yt = get_data_classif('3gauss2', nt)
 
-    otda = ot.da.SinkhornTransport()
+    otda = SinkhornTransport()
 
     # test its computed
     otda.fit(Xs=Xs, Xt=Xt)
@@ -221,11 +229,11 @@ def test_sinkhorn_transport_class():
     assert_equal(transp_Xs.shape, Xs.shape)
 
     # test unsupervised vs semi-supervised mode
-    otda_unsup = ot.da.SinkhornTransport()
+    otda_unsup = SinkhornTransport()
     otda_unsup.fit(Xs=Xs, Xt=Xt)
     n_unsup = np.sum(otda_unsup.cost_)
 
-    otda_semi = ot.da.SinkhornTransport()
+    otda_semi = SinkhornTransport()
     otda_semi.fit(Xs=Xs, ys=ys, Xt=Xt, yt=yt)
     assert_equal(otda_semi.cost_.shape, ((Xs.shape[0], Xt.shape[0])))
     n_semisup = np.sum(otda_semi.cost_)
@@ -240,7 +248,7 @@ def test_sinkhorn_transport_class():
     assert mass_semi == 0, "semisupervised mode not working"
 
     # check everything runs well with log=True
-    otda = ot.da.SinkhornTransport(log=True)
+    otda = SinkhornTransport(log=True)
     otda.fit(Xs=Xs, ys=ys, Xt=Xt)
     assert len(otda.log_.keys()) != 0
 
@@ -255,7 +263,7 @@ def test_emd_transport_class():
     Xs, ys = get_data_classif('3gauss', ns)
     Xt, yt = get_data_classif('3gauss2', nt)
 
-    otda = ot.da.EMDTransport()
+    otda = EMDTransport()
 
     # test its computed
     otda.fit(Xs=Xs, Xt=Xt)
@@ -299,11 +307,11 @@ def test_emd_transport_class():
     assert_equal(transp_Xs.shape, Xs.shape)
 
     # test unsupervised vs semi-supervised mode
-    otda_unsup = ot.da.EMDTransport()
+    otda_unsup = EMDTransport()
     otda_unsup.fit(Xs=Xs, ys=ys, Xt=Xt)
     n_unsup = np.sum(otda_unsup.cost_)
 
-    otda_semi = ot.da.EMDTransport()
+    otda_semi = EMDTransport()
     otda_semi.fit(Xs=Xs, ys=ys, Xt=Xt, yt=yt)
     assert_equal(otda_semi.cost_.shape, ((Xs.shape[0], Xt.shape[0])))
     n_semisup = np.sum(otda_semi.cost_)
@@ -338,7 +346,7 @@ def test_mapping_transport_class():
     ##########################################################################
 
     # check computation and dimensions if bias == False
-    otda = ot.da.MappingTransport(kernel="linear", bias=False)
+    otda = MappingTransport(kernel="linear", bias=False)
     otda.fit(Xs=Xs, Xt=Xt)
     assert hasattr(otda, "coupling_")
     assert hasattr(otda, "mapping_")
@@ -365,7 +373,7 @@ def test_mapping_transport_class():
     assert_equal(transp_Xs_new.shape, Xs_new.shape)
 
     # check computation and dimensions if bias == True
-    otda = ot.da.MappingTransport(kernel="linear", bias=True)
+    otda = MappingTransport(kernel="linear", bias=True)
     otda.fit(Xs=Xs, Xt=Xt)
     assert_equal(otda.coupling_.shape, ((Xs.shape[0], Xt.shape[0])))
     assert_equal(otda.mapping_.shape, ((Xs.shape[1] + 1, Xt.shape[1])))
@@ -392,7 +400,7 @@ def test_mapping_transport_class():
     ##########################################################################
 
     # check computation and dimensions if bias == False
-    otda = ot.da.MappingTransport(kernel="gaussian", bias=False)
+    otda = MappingTransport(kernel="gaussian", bias=False)
     otda.fit(Xs=Xs, Xt=Xt)
 
     assert_equal(otda.coupling_.shape, ((Xs.shape[0], Xt.shape[0])))
@@ -416,7 +424,7 @@ def test_mapping_transport_class():
     assert_equal(transp_Xs_new.shape, Xs_new.shape)
 
     # check computation and dimensions if bias == True
-    otda = ot.da.MappingTransport(kernel="gaussian", bias=True)
+    otda = MappingTransport(kernel="gaussian", bias=True)
     otda.fit(Xs=Xs, Xt=Xt)
     assert_equal(otda.coupling_.shape, ((Xs.shape[0], Xt.shape[0])))
     assert_equal(otda.mapping_.shape, ((Xs.shape[0] + 1, Xt.shape[1])))
@@ -439,7 +447,7 @@ def test_mapping_transport_class():
     assert_equal(transp_Xs_new.shape, Xs_new.shape)
 
     # check everything runs well with log=True
-    otda = ot.da.MappingTransport(kernel="gaussian", log=True)
+    otda = MappingTransport(kernel="gaussian", log=True)
     otda.fit(Xs=Xs, Xt=Xt)
     assert len(otda.log_.keys()) != 0
 
@@ -449,13 +457,13 @@ def test_otda():
     n_samples = 150  # nb samples
     np.random.seed(0)
 
-    xs, ys = ot.datasets.get_data_classif('3gauss', n_samples)
-    xt, yt = ot.datasets.get_data_classif('3gauss2', n_samples)
+    xs, ys = get_data_classif('3gauss', n_samples)
+    xt, yt = get_data_classif('3gauss2', n_samples)
 
-    a, b = ot.unif(n_samples), ot.unif(n_samples)
+    a, b = unif(n_samples), unif(n_samples)
 
     # LP problem
-    da_emd = ot.da.OTDA()     # init class
+    da_emd = OTDA()     # init class
     da_emd.fit(xs, xt)       # fit distributions
     da_emd.interp()    # interpolation of source samples
     da_emd.predict(xs)    # interpolation of source samples
@@ -465,7 +473,7 @@ def test_otda():
 
     # sinkhorn regularization
     lambd = 1e-1
-    da_entrop = ot.da.OTDA_sinkhorn()
+    da_entrop = OTDA_sinkhorn()
     da_entrop.fit(xs, xt, reg=lambd)
     da_entrop.interp()
     da_entrop.predict(xs)
@@ -477,7 +485,7 @@ def test_otda():
     # non-convex Group lasso regularization
     reg = 1e-1
     eta = 1e0
-    da_lpl1 = ot.da.OTDA_lpl1()
+    da_lpl1 = OTDA_lpl1()
     da_lpl1.fit(xs, ys, xt, reg=reg, eta=eta)
     da_lpl1.interp()
     da_lpl1.predict(xs)
@@ -488,7 +496,7 @@ def test_otda():
     # True Group lasso regularization
     reg = 1e-1
     eta = 2e0
-    da_l1l2 = ot.da.OTDA_l1l2()
+    da_l1l2 = OTDA_l1l2()
     da_l1l2.fit(xs, ys, xt, reg=reg, eta=eta, numItermax=20, verbose=True)
     da_l1l2.interp()
     da_l1l2.predict(xs)
@@ -497,11 +505,11 @@ def test_otda():
     np.testing.assert_allclose(b, np.sum(da_l1l2.G, 0), rtol=1e-3, atol=1e-3)
 
     # linear mapping
-    da_emd = ot.da.OTDA_mapping_linear()     # init class
+    da_emd = OTDA_mapping_linear()     # init class
     da_emd.fit(xs, xt, numItermax=10)       # fit distributions
     da_emd.predict(xs)    # interpolation of source samples
 
     # nonlinear mapping
-    da_emd = ot.da.OTDA_mapping_kernel()     # init class
+    da_emd = OTDA_mapping_kernel()     # init class
     da_emd.fit(xs, xt, numItermax=10)       # fit distributions
     da_emd.predict(xs)    # interpolation of source samples

--- a/test/test_dr.py
+++ b/test/test_dr.py
@@ -7,7 +7,6 @@
 import numpy as np
 
 from ot.datasets import get_data_classif
-from ot.dr import fda, wda
 import pytest
 
 try:  # test if autograd and pymanopt are installed

--- a/test/test_dr.py
+++ b/test/test_dr.py
@@ -5,11 +5,13 @@
 # License: MIT License
 
 import numpy as np
-import ot
+
+from ot.datasets import get_data_classif
+from ot.dr import fda, wda
 import pytest
 
 try:  # test if autograd and pymanopt are installed
-    import ot.dr
+    from ot.dr import fda, wda
     nogo = False
 except ImportError:
     nogo = True
@@ -22,7 +24,7 @@ def test_fda():
     np.random.seed(0)
 
     # generate gaussian dataset
-    xs, ys = ot.datasets.get_data_classif('gaussrot', n_samples)
+    xs, ys = get_data_classif('gaussrot', n_samples)
 
     n_features_noise = 8
 
@@ -30,7 +32,7 @@ def test_fda():
 
     p = 1
 
-    Pfda, projfda = ot.dr.fda(xs, ys, p)
+    Pfda, projfda = fda(xs, ys, p)
 
     projfda(xs)
 
@@ -44,7 +46,7 @@ def test_wda():
     np.random.seed(0)
 
     # generate gaussian dataset
-    xs, ys = ot.datasets.get_data_classif('gaussrot', n_samples)
+    xs, ys = get_data_classif('gaussrot', n_samples)
 
     n_features_noise = 8
 
@@ -52,7 +54,7 @@ def test_wda():
 
     p = 2
 
-    Pwda, projwda = ot.dr.wda(xs, ys, p, maxiter=10)
+    Pwda, projwda = wda(xs, ys, p, maxiter=10)
 
     projwda(xs)
 

--- a/test/test_gpu.py
+++ b/test/test_gpu.py
@@ -5,7 +5,8 @@
 # License: MIT License
 
 import numpy as np
-import ot
+from ot.da import OTDA_sinkhorn, OTDA_lpl1
+from ot.gpu.da import OTDA_sinkhorn, OTDA_lpl1
 import time
 import pytest
 
@@ -30,11 +31,11 @@ def test_gpu_sinkhorn():
         a = rng.rand(n_samples // 4, 100)
         b = rng.rand(n_samples, 100)
         time1 = time.time()
-        transport = ot.da.OTDA_sinkhorn()
+        transport = OTDA_sinkhorn()
         transport.fit(a, b)
         G1 = transport.G
         time2 = time.time()
-        transport = ot.gpu.da.OTDA_sinkhorn()
+        transport = OTDA_sinkhorn()
         transport.fit(a, b)
         G2 = transport.G
         time3 = time.time()
@@ -61,11 +62,11 @@ def test_gpu_sinkhorn_lpl1():
         labels_a = np.random.randint(10, size=(n_samples // 4))
         b = rng.rand(n_samples, 100)
         time1 = time.time()
-        transport = ot.da.OTDA_lpl1()
+        transport = OTDA_lpl1()
         transport.fit(a, labels_a, b)
         G1 = transport.G
         time2 = time.time()
-        transport = ot.gpu.da.OTDA_lpl1()
+        transport = OTDA_lpl1()
         transport.fit(a, labels_a, b)
         G2 = transport.G
         time3 = time.time()

--- a/test/test_gpu.py
+++ b/test/test_gpu.py
@@ -5,13 +5,14 @@
 # License: MIT License
 
 import numpy as np
-from ot.da import OTDA_sinkhorn, OTDA_lpl1
-from ot.gpu.da import OTDA_sinkhorn, OTDA_lpl1
 import time
 import pytest
 
+from ot.da import OTDA_sinkhorn, OTDA_lpl1
+
 try:  # test if cudamat installed
-    import ot.gpu
+    from ot.gpu.da import OTDA_sinkhorn as OTDA_sinkhorn_gpu
+    from ot.gpu.da import OTDA_lpl1 as OTDA_lpl1_gpu
     nogpu = False
 except ImportError:
     nogpu = True
@@ -35,7 +36,7 @@ def test_gpu_sinkhorn():
         transport.fit(a, b)
         G1 = transport.G
         time2 = time.time()
-        transport = OTDA_sinkhorn()
+        transport = OTDA_sinkhorn_gpu()
         transport.fit(a, b)
         G2 = transport.G
         time3 = time.time()
@@ -66,7 +67,7 @@ def test_gpu_sinkhorn_lpl1():
         transport.fit(a, labels_a, b)
         G1 = transport.G
         time2 = time.time()
-        transport = OTDA_lpl1()
+        transport = OTDA_lpl1_gpu()
         transport.fit(a, labels_a, b)
         G2 = transport.G
         time3 = time.time()

--- a/test/test_gromov.py
+++ b/test/test_gromov.py
@@ -6,7 +6,10 @@
 # License: MIT License
 
 import numpy as np
-import ot
+
+from ot.datasets import get_2D_samples_gauss
+from ot.utils import unif, dist
+from ot.gromov import gromov_wasserstein
 
 
 def test_gromov():
@@ -15,20 +18,20 @@ def test_gromov():
     mu_s = np.array([0, 0])
     cov_s = np.array([[1, 0], [0, 1]])
 
-    xs = ot.datasets.get_2D_samples_gauss(n_samples, mu_s, cov_s)
+    xs = get_2D_samples_gauss(n_samples, mu_s, cov_s)
 
     xt = xs[::-1].copy()
 
-    p = ot.unif(n_samples)
-    q = ot.unif(n_samples)
+    p = unif(n_samples)
+    q = unif(n_samples)
 
-    C1 = ot.dist(xs, xs)
-    C2 = ot.dist(xt, xt)
+    C1 = dist(xs, xs)
+    C2 = dist(xt, xt)
 
     C1 /= C1.max()
     C2 /= C2.max()
 
-    G = ot.gromov_wasserstein(C1, C2, p, q, 'square_loss', epsilon=5e-4)
+    G = gromov_wasserstein(C1, C2, p, q, 'square_loss', epsilon=5e-4)
 
     # check constratints
     np.testing.assert_allclose(

--- a/test/test_optim.py
+++ b/test/test_optim.py
@@ -5,7 +5,10 @@
 # License: MIT License
 
 import numpy as np
-import ot
+
+from ot.datasets import get_1D_gauss
+from ot.utils import dist
+from ot.optim import cg, gcg
 
 
 def test_conditional_gradient():
@@ -16,11 +19,11 @@ def test_conditional_gradient():
     x = np.arange(n_bins, dtype=np.float64)
 
     # Gaussian distributions
-    a = ot.datasets.get_1D_gauss(n_bins, m=20, s=5)  # m= mean, s= std
-    b = ot.datasets.get_1D_gauss(n_bins, m=60, s=10)
+    a = get_1D_gauss(n_bins, m=20, s=5)  # m= mean, s= std
+    b = get_1D_gauss(n_bins, m=60, s=10)
 
     # loss matrix
-    M = ot.dist(x.reshape((n_bins, 1)), x.reshape((n_bins, 1)))
+    M = dist(x.reshape((n_bins, 1)), x.reshape((n_bins, 1)))
     M /= M.max()
 
     def f(G):
@@ -31,7 +34,7 @@ def test_conditional_gradient():
 
     reg = 1e-1
 
-    G, log = ot.optim.cg(a, b, M, reg, f, df, verbose=True, log=True)
+    G, log = cg(a, b, M, reg, f, df, verbose=True, log=True)
 
     np.testing.assert_allclose(a, G.sum(1))
     np.testing.assert_allclose(b, G.sum(0))
@@ -45,11 +48,11 @@ def test_generalized_conditional_gradient():
     x = np.arange(n_bins, dtype=np.float64)
 
     # Gaussian distributions
-    a = ot.datasets.get_1D_gauss(n_bins, m=20, s=5)  # m= mean, s= std
-    b = ot.datasets.get_1D_gauss(n_bins, m=60, s=10)
+    a = get_1D_gauss(n_bins, m=20, s=5)  # m= mean, s= std
+    b = get_1D_gauss(n_bins, m=60, s=10)
 
     # loss matrix
-    M = ot.dist(x.reshape((n_bins, 1)), x.reshape((n_bins, 1)))
+    M = dist(x.reshape((n_bins, 1)), x.reshape((n_bins, 1)))
     M /= M.max()
 
     def f(G):
@@ -61,7 +64,7 @@ def test_generalized_conditional_gradient():
     reg1 = 1e-3
     reg2 = 1e-1
 
-    G, log = ot.optim.gcg(a, b, M, reg1, reg2, f, df, verbose=True, log=True)
+    G, log = gcg(a, b, M, reg1, reg2, f, df, verbose=True, log=True)
 
     np.testing.assert_allclose(a, G.sum(1), atol=1e-05)
     np.testing.assert_allclose(b, G.sum(0), atol=1e-05)

--- a/test/test_plot.py
+++ b/test/test_plot.py
@@ -6,12 +6,15 @@
 
 import numpy as np
 import matplotlib
+
+from ot.datasets import get_1D_gauss, get_2D_samples_gauss
+from ot.utils import dist
+from ot.plot import plot1D_mat, plot2D_samples_mat
+
 matplotlib.use('Agg')
 
 
 def test_plot1D_mat():
-
-    import ot
 
     n_bins = 100  # nb bins
 
@@ -19,19 +22,17 @@ def test_plot1D_mat():
     x = np.arange(n_bins, dtype=np.float64)
 
     # Gaussian distributions
-    a = ot.datasets.get_1D_gauss(n_bins, m=20, s=5)  # m= mean, s= std
-    b = ot.datasets.get_1D_gauss(n_bins, m=60, s=10)
+    a = get_1D_gauss(n_bins, m=20, s=5)  # m= mean, s= std
+    b = get_1D_gauss(n_bins, m=60, s=10)
 
     # loss matrix
-    M = ot.dist(x.reshape((n_bins, 1)), x.reshape((n_bins, 1)))
+    M = dist(x.reshape((n_bins, 1)), x.reshape((n_bins, 1)))
     M /= M.max()
 
-    ot.plot.plot1D_mat(a, b, M, 'Cost matrix M')
+    plot1D_mat(a, b, M, 'Cost matrix M')
 
 
 def test_plot2D_samples_mat():
-
-    import ot
 
     n_bins = 50  # nb samples
 
@@ -41,9 +42,9 @@ def test_plot2D_samples_mat():
     mu_t = np.array([4, 4])
     cov_t = np.array([[1, -.8], [-.8, 1]])
 
-    xs = ot.datasets.get_2D_samples_gauss(n_bins, mu_s, cov_s)
-    xt = ot.datasets.get_2D_samples_gauss(n_bins, mu_t, cov_t)
+    xs = get_2D_samples_gauss(n_bins, mu_s, cov_s)
+    xt = get_2D_samples_gauss(n_bins, mu_t, cov_t)
 
     G = 1.0 * (np.random.rand(n_bins, n_bins) < 0.01)
 
-    ot.plot.plot2D_samples_mat(xs, xt, G, thr=1e-5)
+    plot2D_samples_mat(xs, xt, G, thr=1e-5)

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -5,8 +5,10 @@
 # License: MIT License
 
 
-import ot
 import numpy as np
+
+from ot.utils import (parmap, tic, toc, kernel, toq, dist, dist0,
+                      dots, unif, clean_zeros)
 
 
 def test_parmap():
@@ -20,7 +22,7 @@ def test_parmap():
 
     l1 = list(map(f, a))
 
-    l2 = list(ot.utils.parmap(f, a))
+    l2 = list(parmap(f, a))
 
     np.testing.assert_allclose(l1, l2)
 
@@ -29,10 +31,10 @@ def test_tic_toc():
 
     import time
 
-    ot.tic()
+    tic()
     time.sleep(0.5)
-    t = ot.toc()
-    t2 = ot.toq()
+    t = toc()
+    t2 = toq()
 
     # test timing
     np.testing.assert_allclose(0.5, t, rtol=1e-2, atol=1e-2)
@@ -47,7 +49,7 @@ def test_kernel():
 
     x = np.random.randn(n, 2)
 
-    K = ot.utils.kernel(x, x)
+    K = kernel(x, x)
 
     # gaussian kernel  has ones on the diagonal
     np.testing.assert_allclose(np.diag(K), np.ones(n))
@@ -57,7 +59,7 @@ def test_unif():
 
     n = 100
 
-    u = ot.unif(n)
+    u = unif(n)
 
     np.testing.assert_allclose(1, np.sum(u))
 
@@ -73,8 +75,8 @@ def test_dist():
         for j in range(n):
             D[i, j] = np.sum(np.square(x[i, :] - x[j, :]))
 
-    D2 = ot.dist(x, x)
-    D3 = ot.dist(x)
+    D2 = dist(x, x)
+    D3 = dist(x)
 
     # dist shoul return squared euclidean
     np.testing.assert_allclose(D, D2)
@@ -84,7 +86,7 @@ def test_dist():
 def test_dist0():
 
     n = 100
-    M = ot.utils.dist0(n, method='lin_square')
+    M = dist0(n, method='lin_square')
 
     # dist0 default to linear sampling with quadratic loss
     np.testing.assert_allclose(M[0, -1], (n - 1) * (n - 1))
@@ -98,7 +100,7 @@ def test_dots():
     B = np.random.randn(n2, n3)
     C = np.random.randn(n3, n4)
 
-    X1 = ot.utils.dots(A, B, C)
+    X1 = dots(A, B, C)
 
     X2 = A.dot(B.dot(C))
 
@@ -110,16 +112,16 @@ def test_clean_zeros():
     n = 100
     nz = 50
     nz2 = 20
-    u1 = ot.unif(n)
+    u1 = unif(n)
     u1[:nz] = 0
     u1 = u1 / u1.sum()
-    u2 = ot.unif(n)
+    u2 = unif(n)
     u2[:nz2] = 0
     u2 = u2 / u2.sum()
 
-    M = ot.utils.dist0(n)
+    M = dist0(n)
 
-    a, b, M2 = ot.utils.clean_zeros(u1, u2, M)
+    a, b, M2 = clean_zeros(u1, u2, M)
 
     assert len(a) == n - nz
     assert len(b) == n - nz2


### PR DESCRIPTION
This PR intends to remove all automatics imports when importing the library.

In particular, it solves crashes when pot is imported on a instance without connected display device.