### PR TITLE
Speedup Sinkhorn with einsum + bench

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,12 +59,12 @@ notebook :
 	ipython notebook --matplotlib=inline  --notebook-dir=notebooks/
 	
 bench :
-	echo 'Branch master'
+	@echo 'Branch master'
 	git checkout master
-	python3 $(script)
-	echo 'Branch $(branch)'
+	#python3 $(script)
+	@echo 'Branch $(branch)'
 	git checkout $(branch)
-	python3 $(script)
+	#python3 $(script)
 	
 autopep8 :
 	autopep8 -ir test ot examples --jobs -1

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 
 
 PYTHON=python3
-branch := $(git symbolic-ref --short -q HEAD)
+branch := $(eval git symbolic-ref --short -q HEAD)
 
 help :
 	@echo "The following make targets are available:"
@@ -58,7 +58,7 @@ rdoc :
 notebook :
 	ipython notebook --matplotlib=inline  --notebook-dir=notebooks/
 	
-bench :
+bench : FORCE
 	@echo 'Branch master'
 	git checkout master
 	#python3 $(script)

--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,14 @@ rdoc :
 notebook :
 	ipython notebook --matplotlib=inline  --notebook-dir=notebooks/
 	
+bench :
+	echo 'Branch master'
+	git checkout master
+	python3 $(script)
+	echo 'Branch $(branch)'
+	git checkout $(branch)
+	python3 $(script)
+	
 autopep8 :
 	autopep8 -ir test ot examples --jobs -1
 

--- a/Makefile
+++ b/Makefile
@@ -59,12 +59,14 @@ notebook :
 	ipython notebook --matplotlib=inline  --notebook-dir=notebooks/
 	
 bench : 
+	@git stash  >/dev/null 2>&1
 	@echo 'Branch master'
-	git checkout master
+	@git checkout master >/dev/null 2>&1
 	python3 $(script)
 	@echo 'Branch $(branch)'
-	git checkout $(branch)
+	@git checkout $(branch) >/dev/null 2>&1
 	python3 $(script)
+	@git stash apply >/dev/null 2>&1
 	
 autopep8 :
 	autopep8 -ir test ot examples --jobs -1

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 
 
 PYTHON=python3
-branch := $(eval git symbolic-ref --short -q HEAD)
+branch := $(shell git symbolic-ref --short -q HEAD)
 
 help :
 	@echo "The following make targets are available:"
@@ -58,7 +58,7 @@ rdoc :
 notebook :
 	ipython notebook --matplotlib=inline  --notebook-dir=notebooks/
 	
-bench : FORCE
+bench : 
 	@echo 'Branch master'
 	git checkout master
 	#python3 $(script)

--- a/Makefile
+++ b/Makefile
@@ -61,10 +61,10 @@ notebook :
 bench : 
 	@echo 'Branch master'
 	git checkout master
-	#python3 $(script)
+	python3 $(script)
 	@echo 'Branch $(branch)'
 	git checkout $(branch)
-	#python3 $(script)
+	python3 $(script)
 	
 autopep8 :
 	autopep8 -ir test ot examples --jobs -1

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 
 
 PYTHON=python3
+branch := $(git symbolic-ref --short -q HEAD)
 
 help :
 	@echo "The following make targets are available:"

--- a/ot/bregman.py
+++ b/ot/bregman.py
@@ -396,10 +396,7 @@ def sinkhorn_knopp(a, b, M, reg, numItermax=1000,
         log['v'] = v
 
     if nbb:  # return only loss
-        res = np.zeros((nbb))
-        for i in range(nbb):
-            res[i] = np.sum(
-                u[:, i].reshape((-1, 1)) * K * v[:, i].reshape((1, -1)) * M)
+        res = np.einsum('ik,ij,jk,ij->k', u, K, v, M)
         if log:
             return res, log
         else:

--- a/ot/bregman.py
+++ b/ot/bregman.py
@@ -358,9 +358,14 @@ def sinkhorn_knopp(a, b, M, reg, numItermax=1000,
     while (err > stopThr and cpt < numItermax):
         uprev = u
         vprev = v
-        KtransposeU = np.einsum('ij,i->j',K,u)#np.dot(K.T, u)
-        v = np.divide(b, KtransposeU)
-        u = 1. / np.einsum('ij,j->i',Kp,v)#np.dot(Kp, v)
+        if nbb:
+            KtransposeU = np.einsum('ij,i,k->jk',K,u)#np.dot(K.T, u)
+            v = np.divide(b, KtransposeU)
+            u = 1. / np.einsum('ij,jk->ik',Kp,v)#np.dot(Kp, v)
+        else:
+            KtransposeU = np.einsum('ij,i->j',K,u)#np.dot(K.T, u)
+            v = np.divide(b, KtransposeU)
+            u = 1. / np.einsum('ij,j->i',Kp,v)#np.dot(Kp, v)            
 
         if (np.any(KtransposeU == 0) or
                 np.any(np.isnan(u)) or np.any(np.isnan(v)) or

--- a/ot/bregman.py
+++ b/ot/bregman.py
@@ -358,9 +358,9 @@ def sinkhorn_knopp(a, b, M, reg, numItermax=1000,
     while (err > stopThr and cpt < numItermax):
         uprev = u
         vprev = v
-        KtransposeU = np.dot(K.T, u)
+        KtransposeU = np.einsum('ij,i->j',K,u)#np.dot(K.T, u)
         v = np.divide(b, KtransposeU)
-        u = 1. / np.dot(Kp, v)
+        u = 1. / np.einsum('ij,j->i',Kp,v)#np.dot(Kp, v)
 
         if (np.any(KtransposeU == 0) or
                 np.any(np.isnan(u)) or np.any(np.isnan(v)) or

--- a/ot/bregman.py
+++ b/ot/bregman.py
@@ -362,7 +362,6 @@ def sinkhorn_knopp(a, b, M, reg, numItermax=1000,
         KtransposeU = np.dot(K.T, u)
         v = np.divide(b, KtransposeU)
         u = 1. / np.dot(Kp, v)
-       
 
         if (np.any(KtransposeU == 0) or
                 np.any(np.isnan(u)) or np.any(np.isnan(v)) or

--- a/ot/bregman.py
+++ b/ot/bregman.py
@@ -350,7 +350,6 @@ def sinkhorn_knopp(a, b, M, reg, numItermax=1000,
     np.exp(K, out=K)
 
     # print(np.min(K))
-    tmp = np.empty(K.shape, dtype=M.dtype)
     tmp2 = np.empty(b.shape, dtype=M.dtype)
 
     Kp = (1 / a).reshape(-1, 1) * K
@@ -379,11 +378,9 @@ def sinkhorn_knopp(a, b, M, reg, numItermax=1000,
                 err = np.sum((u - uprev)**2) / np.sum((u)**2) + \
                     np.sum((v - vprev)**2) / np.sum((v)**2)
             else:
-                np.multiply(u.reshape(-1, 1), K, out=tmp)
-                np.multiply(tmp, v.reshape(1, -1), out=tmp)
-                np.sum(tmp, axis=0, out=tmp2)
-                tmp2 -= b
-                err = np.linalg.norm(tmp2)**2
+                # compute right marginal tmp2= (diag(u)Kdiag(v))^T1 
+                np.einsum('i,ij,j->j',u,K,v,out=tmp2)
+                err = np.linalg.norm(tmp2-b)**2 # violation of marginal
             if log:
                 log['err'].append(err)
 

--- a/ot/bregman.py
+++ b/ot/bregman.py
@@ -359,7 +359,7 @@ def sinkhorn_knopp(a, b, M, reg, numItermax=1000,
         uprev = u
         vprev = v
         if nbb:
-            KtransposeU = np.einsum('ij,i,k->jk',K,u)#np.dot(K.T, u)
+            KtransposeU = np.einsum('ij,ik->jk',K,u)#np.dot(K.T, u)
             v = np.divide(b, KtransposeU)
             u = 1. / np.einsum('ij,jk->ik',Kp,v)#np.dot(Kp, v)
         else:

--- a/ot/bregman.py
+++ b/ot/bregman.py
@@ -378,9 +378,9 @@ def sinkhorn_knopp(a, b, M, reg, numItermax=1000,
                 err = np.sum((u - uprev)**2) / np.sum((u)**2) + \
                     np.sum((v - vprev)**2) / np.sum((v)**2)
             else:
-                # compute right marginal tmp2= (diag(u)Kdiag(v))^T1 
-                np.einsum('i,ij,j->j',u,K,v,out=tmp2)
-                err = np.linalg.norm(tmp2-b)**2 # violation of marginal
+                # compute right marginal tmp2= (diag(u)Kdiag(v))^T1
+                np.einsum('i,ij,j->j', u, K, v, out=tmp2)
+                err = np.linalg.norm(tmp2 - b)**2  # violation of marginal
             if log:
                 log['err'].append(err)
 

--- a/ot/bregman.py
+++ b/ot/bregman.py
@@ -358,14 +358,11 @@ def sinkhorn_knopp(a, b, M, reg, numItermax=1000,
     while (err > stopThr and cpt < numItermax):
         uprev = u
         vprev = v
-        if nbb:
-            KtransposeU = np.einsum('ij,ik->jk',K,u)#np.dot(K.T, u)
-            v = np.divide(b, KtransposeU)
-            u = 1. / np.einsum('ij,jk->ik',Kp,v)#np.dot(Kp, v)
-        else:
-            KtransposeU = np.einsum('ij,i->j',K,u)#np.dot(K.T, u)
-            v = np.divide(b, KtransposeU)
-            u = 1. / np.einsum('ij,j->i',Kp,v)#np.dot(Kp, v)            
+
+        KtransposeU = np.dot(K.T, u)
+        v = np.divide(b, KtransposeU)
+        u = 1. / np.dot(Kp, v)
+       
 
         if (np.any(KtransposeU == 0) or
                 np.any(np.isnan(u)) or np.any(np.isnan(v)) or


### PR DESCRIPTION
Hello,

Since @LeoGautheron and the sklearn devellopers opened my  eyes about einsum, I found some new speedup especially on the test of violation of the marginals constraints. I also use einsum to compute the final loss for paralell sinkhorn computations.

 
With the following benchmark 

```python
import time
import numpy as np
import ot
rng = np.random.RandomState(0)

n=5000
d=2
b=5
reg=1e0
Xs, ys, Xt = rng.randn(n, d), rng.randint(0, 2, size=n), rng.randn(n, d)

a=ot.unif(n)
B=np.ones((n,b))/n

M=ot.dist(Xs,Xt)

time1 = time.time()
res=ot.sinkhorn(a,a,M,reg,verbose=True)
time2 = time.time()
print("Sinkhorn Computation Time {:6.2f} sec".format(time2-time1))

time1 = time.time()
res=ot.sinkhorn(a,B,M,reg,verbose=True)
time2 = time.time()
print("Multi Sinkhorn Computation Time {:6.2f} sec".format(time2-time1))
print(res)

```

I get the following outputs for master and my branch

```
Branch master
python3 mytest/test_einsum.py
It.  |Err         
-------------------
    0|5.449272e-06|
   10|7.115862e-12|
Sinkhorn Computation Time   2.07 sec
It.  |Err         
-------------------
    0|1.293152e+00|
   10|6.770311e-07|
   20|2.770657e-11|
Multi Sinkhorn Computation Time   8.75 sec
[0.8783663 0.8783663 0.8783663 0.8783663 0.8783663]
Branch speedup
python3 mytest/test_einsum.py
It.  |Err         
-------------------
    0|5.449272e-06|
   10|7.115862e-12|
Sinkhorn Computation Time   1.73 sec
It.  |Err         
-------------------
    0|1.293152e+00|
   10|6.770311e-07|
   20|2.770657e-11|
Multi Sinkhorn Computation Time   8.08 sec
[0.8783663 0.8783663 0.8783663 0.8783663 0.8783663]

```

I also added a nice make option for benchmarks that run a script twice by comparing it to the master branch with the following command:

```
make bench script=yourscript.py branch=thebranch
```