### PR TITLE
better implementation on gradient updates

### DIFF
--- a/ot/stochastic.py
+++ b/ot/stochastic.py
@@ -617,8 +617,8 @@ def sgd_entropic_regularization(a, b, M, reg, batch_size, numItermax, lr):
         update_alpha, update_beta = batch_grad_dual(a, b, M, reg, cur_alpha,
                                                     cur_beta, batch_size,
                                                     batch_alpha, batch_beta)
-        cur_alpha += (lr / k) * update_alpha
-        cur_beta += (lr / k) * update_beta
+        cur_alpha[batch_alpha] += (lr / k) * update_alpha[batch_alpha]
+        cur_beta[batch_beta] += (lr / k) * update_beta[batch_beta]
 
     return cur_alpha, cur_beta
 


### PR DESCRIPTION
Hello!

I would like to request a PR for the stochastic framework. It is a small modification of the dual solver. I just update the dual variable coordinates which are in the batch. Because the partial gradients are sparse, it avoids to update the dual variables with 0.

I tested it : 

For uniform distributions
len(\alpha) = 700
len(\beta) = 500
batch_size = 200
num_iter = 100000
time before modification : 191 s
time after modification : 177 s

So as you can see, there is a huge potential in large scale settings. 

Thank you.