### PR TITLE
[MRG] corrected typos in barycenter examples

### DIFF
--- a/examples/plot_barycenter_lp_vs_entropic.py
+++ b/examples/plot_barycenter_lp_vs_entropic.py
@@ -102,7 +102,7 @@ pl.tight_layout()
 problems.append([A, [bary_l2, bary_wass, bary_wass2]])
 
 ##############################################################################
-# Dirac Data
+# Stair Data
 # ----------
 
 #%% parameters
@@ -167,6 +167,11 @@ pl.plot(x, bary_wass2, 'b', label='LP Wasserstein')
 pl.legend()
 pl.title('Barycenters')
 pl.tight_layout()
+
+
+##############################################################################
+# Dirac Data
+# ----------
 
 #%% parameters
 

--- a/examples/plot_free_support_barycenter.py
+++ b/examples/plot_free_support_barycenter.py
@@ -62,7 +62,7 @@ X = ot.lp.free_support_barycenter(measures_locations, measures_weights, X_init, 
 pl.figure(1)
 for (x_i, b_i) in zip(measures_locations, measures_weights):
     color = np.random.randint(low=1, high=10 * N)
-    pl.scatter(x_i[:, 0], x_i[:, 1], s=b * 1000, label='input measure')
+    pl.scatter(x_i[:, 0], x_i[:, 1], s=b_i * 1000, label='input measure')
 pl.scatter(X[:, 0], X[:, 1], s=b * 1000, c='black', marker='^', label='2-Wasserstein barycenter')
 pl.title('Data measures and their barycenter')
 pl.legend(loc=0)


### PR DESCRIPTION
Hello,

I am sending a pull request after catching some typos in barycenter examples. In the PR you will find:
- Fix comments in plot_free_support_barycenter.py 
- Fix plot in plot_barycenter_lp_vs_entropic.py