### PR TITLE
MRG: Forgotten weights arg in barycenter funcs

### DIFF
--- a/ot/bregman.py
+++ b/ot/bregman.py
@@ -1037,11 +1037,13 @@ def barycenter(A, M, reg, weights=None, method="sinkhorn", numItermax=10000,
     """
 
     if method.lower() == 'sinkhorn':
-        return barycenter_sinkhorn(A, M, reg, numItermax=numItermax,
+        return barycenter_sinkhorn(A, M, reg, weights=weights,
+                                   numItermax=numItermax,
                                    stopThr=stopThr, verbose=verbose, log=log,
                                    **kwargs)
     elif method.lower() == 'sinkhorn_stabilized':
-        return barycenter_stabilized(A, M, reg, numItermax=numItermax,
+        return barycenter_stabilized(A, M, reg, weights=weights,
+                                     numItermax=numItermax,
                                      stopThr=stopThr, verbose=verbose,
                                      log=log, **kwargs)
     else:

--- a/ot/unbalanced.py
+++ b/ot/unbalanced.py
@@ -1002,12 +1002,14 @@ def barycenter_unbalanced(A, M, reg, reg_m, method="sinkhorn", weights=None,
 
     if method.lower() == 'sinkhorn':
         return barycenter_unbalanced_sinkhorn(A, M, reg, reg_m,
+                                              weights=weights,
                                               numItermax=numItermax,
                                               stopThr=stopThr, verbose=verbose,
                                               log=log, **kwargs)
 
     elif method.lower() == 'sinkhorn_stabilized':
         return barycenter_unbalanced_stabilized(A, M, reg, reg_m,
+                                                weights=weights,
                                                 numItermax=numItermax,
                                                 stopThr=stopThr,
                                                 verbose=verbose,
@@ -1015,6 +1017,7 @@ def barycenter_unbalanced(A, M, reg, reg_m, method="sinkhorn", weights=None,
     elif method.lower() in ['sinkhorn_reg_scaling']:
         warnings.warn('Method not implemented yet. Using classic Sinkhorn Knopp')
         return barycenter_unbalanced(A, M, reg, reg_m,
+                                     weights=weights,
                                      numItermax=numItermax,
                                      stopThr=stopThr, verbose=verbose,
                                      log=log, **kwargs)


### PR DESCRIPTION
- [x] Tiny fix: the `weights` arg was not passed in the general barycenter funcs.
- [x]  Loop counter in `barycenter_unbalanced` was outside the loop -> change `while` loops to `for` loops
- [x]  Adding 1e-16 to avoid 0 when dual variables are returned was too conservative and causes large differences in the exponentials. changed to 1e-300
