### PR TITLE
[MRG] Add assert for emd dimension mismatch

### DIFF
--- a/ot/lp/__init__.py
+++ b/ot/lp/__init__.py
@@ -109,6 +109,9 @@ def emd(a, b, M, numItermax=100000, log=False):
     if len(b) == 0:
         b = np.ones((M.shape[1],), dtype=np.float64) / M.shape[1]
 
+    assert (a.shape[0] == M.shape[0] or b.shape[0] == M.shape[1]), \
+        "Dimension mismatch, check dimensions of M with a and b"
+
     G, cost, u, v, result_code = emd_c(a, b, M, numItermax)
     result_code_string = check_result(result_code)
     if log:
@@ -211,6 +214,9 @@ def emd2(a, b, M, processes=multiprocessing.cpu_count(),
         a = np.ones((M.shape[0],), dtype=np.float64) / M.shape[0]
     if len(b) == 0:
         b = np.ones((M.shape[1],), dtype=np.float64) / M.shape[1]
+
+    assert (a.shape[0] == M.shape[0] or b.shape[0] == M.shape[1]), \
+        "Dimension mismatch, check dimensions of M with a and b"
 
     if log or return_matrix:
         def f(b):

--- a/ot/lp/__init__.py
+++ b/ot/lp/__init__.py
@@ -109,7 +109,7 @@ def emd(a, b, M, numItermax=100000, log=False):
     if len(b) == 0:
         b = np.ones((M.shape[1],), dtype=np.float64) / M.shape[1]
 
-    assert (a.shape[0] == M.shape[0] or b.shape[0] == M.shape[1]), \
+    assert (a.shape[0] == M.shape[0] and b.shape[0] == M.shape[1]), \
         "Dimension mismatch, check dimensions of M with a and b"
 
     G, cost, u, v, result_code = emd_c(a, b, M, numItermax)
@@ -215,7 +215,7 @@ def emd2(a, b, M, processes=multiprocessing.cpu_count(),
     if len(b) == 0:
         b = np.ones((M.shape[1],), dtype=np.float64) / M.shape[1]
 
-    assert (a.shape[0] == M.shape[0] or b.shape[0] == M.shape[1]), \
+    assert (a.shape[0] == M.shape[0] and b.shape[0] == M.shape[1]), \
         "Dimension mismatch, check dimensions of M with a and b"
 
     if log or return_matrix:

--- a/test/test_ot.py
+++ b/test/test_ot.py
@@ -14,8 +14,9 @@ from ot.datasets import make_1D_gauss as gauss
 import pytest
 
 
+
 def test_emd_dimension_mismatch():
-    # test emd and emd2 for simple identity
+    # test emd and emd2 for dimension mismatch
     n_samples = 100
     n_features = 2
     rng = np.random.RandomState(0)
@@ -25,9 +26,9 @@ def test_emd_dimension_mismatch():
 
     M = ot.dist(x, x)
 
-    np.testing.assert_raises(AssertionError, emd, a, a, M)
+    np.testing.assert_raises(AssertionError, ot.emd, a, a, M)
 
-    np.testing.assert_raises(AssertionError, emd2, a, a, M)
+    np.testing.assert_raises(AssertionError, ot.emd2, a, a, M)
 
 
 def test_emd_emd2():

--- a/test/test_ot.py
+++ b/test/test_ot.py
@@ -14,6 +14,22 @@ from ot.datasets import make_1D_gauss as gauss
 import pytest
 
 
+def test_emd_dimension_mismatch():
+    # test emd and emd2 for simple identity
+    n_samples = 100
+    n_features = 2
+    rng = np.random.RandomState(0)
+
+    x = rng.randn(n_samples, n_features)
+    a = ot.utils.unif(n_samples + 1)
+
+    M = ot.dist(x, x)
+
+    np.testing.assert_raises(AssertionError, emd, a, a, M)
+
+    np.testing.assert_raises(AssertionError, emd2, a, a, M)
+
+
 def test_emd_emd2():
     # test emd and emd2 for simple identity
     n = 100

--- a/test/test_ot.py
+++ b/test/test_ot.py
@@ -14,7 +14,6 @@ from ot.datasets import make_1D_gauss as gauss
 import pytest
 
 
-
 def test_emd_dimension_mismatch():
     # test emd and emd2 for dimension mismatch
     n_samples = 100


### PR DESCRIPTION
Hello,

I am sending a PR with a patch to issue 114. In this PR, you will find:

. An assert condition (M dimensions with a and b)
. Test to catch the Assertion error.