### PR TITLE
[WIP] Bug on dual potential (constraint violation when some weights are 0)

### DIFF
--- a/ot/lp/emd_wrap.pyx
+++ b/ot/lp/emd_wrap.pyx
@@ -66,6 +66,12 @@ def emd_c(np.ndarray[double, ndim=1, mode="c"] a, np.ndarray[double, ndim=1, mod
     .. warning::
         Note that the M matrix needs to be a C-order :py.cls:`numpy.array`
 
+    .. warning::
+        The C++ solver discards all samples in the distributions with 
+        zeros weights. This means that while the primal variable (transport 
+        matrix) is exact, the solver only returns feasible dual potentials
+        on the samples with weights different from zero. 
+
     Parameters
     ----------
     a : (ns,) numpy.ndarray, float64

--- a/ot/lp/emd_wrap.pyx
+++ b/ot/lp/emd_wrap.pyx
@@ -40,6 +40,8 @@ def check_result(result_code):
     return message
 
 
+
+
 @cython.boundscheck(False)
 @cython.wraparound(False)
 def emd_c(np.ndarray[double, ndim=1, mode="c"] a, np.ndarray[double, ndim=1, mode="c"]  b, np.ndarray[double, ndim=2, mode="c"]  M, int max_iter, bint dense):

--- a/test/test_ot.py
+++ b/test/test_ot.py
@@ -337,7 +337,10 @@ def test_dual_variables():
     # Check that both cost computations are equivalent
     np.testing.assert_almost_equal(cost1, log['cost'])
     check_duality_gap(a, b, M, G, log['u'], log['v'], log['cost'])
-
+    
+    viol=log['u'][:,None]+log['v'][None,:]-M
+    
+    assert viol.max()<1e-8
 
 def check_duality_gap(a, b, M, G, u, v, cost):
     cost_dual = np.vdot(a, u) + np.vdot(b, v)

--- a/test/test_ot.py
+++ b/test/test_ot.py
@@ -337,10 +337,11 @@ def test_dual_variables():
     # Check that both cost computations are equivalent
     np.testing.assert_almost_equal(cost1, log['cost'])
     check_duality_gap(a, b, M, G, log['u'], log['v'], log['cost'])
-    
-    viol=log['u'][:,None]+log['v'][None,:]-M
-    
-    assert viol.max()<1e-8
+
+    viol = log['u'][:, None] + log['v'][None, :] - M
+
+    assert viol.max() < 1e-8
+
 
 def check_duality_gap(a, b, M, G, u, v, cost):
     cost_dual = np.vdot(a, u) + np.vdot(b, v)

--- a/test/test_ot.py
+++ b/test/test_ot.py
@@ -338,9 +338,9 @@ def test_dual_variables():
     np.testing.assert_almost_equal(cost1, log['cost'])
     check_duality_gap(a, b, M, G, log['u'], log['v'], log['cost'])
 
-    viol = log['u'][:, None] + log['v'][None, :] - M
+    constraint_violation = log['u'][:, None] + log['v'][None, :] - M
 
-    assert viol.max() < 1e-8
+    assert constraint_violation.max() < 1e-8
 
 
 def check_duality_gap(a, b, M, G, u, v, cost):


### PR DESCRIPTION
I just discovered this important bug in the `ot.emd``function and it feels like opening pandoras's box.

I added in the fisrt commit a test that checks that the constraints are satisfied and we can see in the travis build that the test fails. This comes from the fact that the c++ emd solver is sparse in the sens that if a weight is 0 it will discard the bin and solve a smaller subproblem on the histograms that have non-zero weights. It works very well and is very efficient in practice bug it does not return proper dual variables because it sets the value for the bins with 0 weight to 0 which can lead to constraint violation in practice.

What I will do in this PR:
- [x] Correct the bug:  `ot.emd` should work by default (return proper dual variables/subgradients)
- [x] add a postprocessing (as default but and ot.emd parameter) to the dual potential so that they are in a way 'centered' because the invariance to a constant can be a big problem in practice when using theme as subgradients. The pre-processing will not change the objective value but provide some stability (and will always return one of the possible solution).

The post-processing is actually necessary when trying to estimate correct dual variable from the optimal sub-problem if we want to avoid bias in the resulting dual potentials (bnasically everyone at 0 on either the left or right potential).  

 